### PR TITLE
Updates the call to create an Argon2 password to the Argon2 1.0 Api

### DIFF
--- a/devise-argon2.gemspec
+++ b/devise-argon2.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'devise', '>= 2.1.0'
   gem.add_dependency 'devise-encryptable', '>= 0.2.0'
-  gem.add_dependency 'argon2', '>= 0.1.4'
+  gem.add_dependency 'argon2', '~> 1.0'
 end

--- a/lib/devise/encryptable/encryptors/argon2.rb
+++ b/lib/devise/encryptable/encryptors/argon2.rb
@@ -5,7 +5,7 @@ module Devise
     module Encryptors
       class Argon2 < Base
         def self.digest(password, stretches, salt, pepper)
-          ::Argon2::Password.hash("#{password}#{salt}#{pepper}")
+          ::Argon2::Password.create("#{password}#{salt}#{pepper}")
         end
 
         def self.compare(encrypted_password, password, stretches, salt, pepper)

--- a/lib/devise/encryptable/encryptors/argon2/version.rb
+++ b/lib/devise/encryptable/encryptors/argon2/version.rb
@@ -1,7 +1,7 @@
 module Devise
   module Encryptable
     module Encryptors
-      ARGON2_VERSION = '1.0.0'
+      ARGON2_VERSION = '1.0.1'
     end
   end
 end

--- a/spec/devise-argon2_spec.rb
+++ b/spec/devise-argon2_spec.rb
@@ -9,7 +9,7 @@ describe Devise::Encryptable::Encryptors::Argon2 do
   let(:stretches) { 10 }
 
   describe ".compare" do
-    let(:encrypted) { Argon2::Password.hash("#{password}#{salt}#{pepper}").to_s }
+    let(:encrypted) { Argon2::Password.create("#{password}#{salt}#{pepper}").to_s }
 
     it "is true when comparing an encrypted password against given plaintext" do
       expect(argon2.compare(encrypted, password, stretches, salt, pepper)).to be true


### PR DESCRIPTION
- the API of the ruby-argon2 gem changed to version 1.0.0 
- #hash became #create see https://github.com/technion/ruby-argon2/blob/master/lib%2Fargon2.rb
- solves #3 
