### PR TITLE
Support argon2 v2.0

### DIFF
--- a/devise-argon2.gemspec
+++ b/devise-argon2.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'devise', '>= 2.1.0'
   gem.add_dependency 'devise-encryptable', '>= 0.2.0'
-  gem.add_dependency 'argon2', '~> 1.0'
+  gem.add_dependency 'argon2', '>= 1.0'
 end


### PR DESCRIPTION
Hey @erdostom, thanks for this nice project 👍 

argon2 v2.0 defaults to Argon2id for new hashes, while still being able to verify existing hashes.

https://github.com/technion/ruby-argon2/blob/master/Changelog.md