### PR TITLE
Gemspec & CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1', '3.2', 'ruby-head']
         rails-version: ['~> 7.0', '~> 6.1']
+        argon2-version: ['2.2', '2.3']
         orm:
           - adapter: active_record
           - adapter: mongoid
@@ -18,18 +19,36 @@ jobs:
           - adapter: mongoid
             mongoid-version: 7.5.4
         include:
+          - rails-version: '~> 6.1'
+            ruby-version: '3.1'
+            argon2-version: '2.3'
+            devise-version: '4.8'
+            orm:
+              adapter: active_record
           - rails-version: '~> 7.1'
             ruby-version: '3.1'
+            argon2-version: '2.3'
+            devise-version: '4.9'
             orm:
               adapter: active_record
           - rails-version: '~> 7.1'
             ruby-version: '3.2'
+            argon2-version: '2.3'
+            devise-version: '4.9'
+            orm:
+              adapter: active_record
+          - rails-version: '~> 7.1'
+            ruby-version: '3.1'
+            argon2-version: '2.1'
+            devise-version: '4.9'
             orm:
               adapter: active_record
     env:
       RAILS_VERSION: ${{ matrix.rails-version  || '~> 7.0'}}
       MONGOID_VERSION: ${{ matrix.orm.mongoid-version || '8.1.2'}}
       ORM: ${{ matrix.orm.adapter }}
+      ARGON2_VERSION: ${{ matrix.argon2-version }}
+      DEVISE_VERSION: ${{ matrix.devise-version || '~> 4.9' }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ rdoc
 spec/reports
 spec/rails_app/log/*
 spec/rails_app/tmp/*
-spec/rails_app/db/test.sqlite3
+spec/rails_app/db/test.sqlite3*
 test/tmp
 test/version_tmp
 tmp

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'simplecov'
 gem 'activerecord'
 gem 'sqlite3'
 gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0'
+gem 'argon2', ENV['ARGON2_VERSION'] || '~> 2.3'
+gem 'devise', ENV['DEVISE_VERSION'] || '~> 4.9'
 
 if ENV['ORM'] == 'mongoid'
   gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.5'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ or `secret` to `Argon2::Password.new`. These parameters can be set like this:
 class User < ApplicationRecord
   devise :database_authenticatable,
     :argon2,
-    argon2_options: {  t_cost: 3, p_cost: 2 }
+    argon2_options: { t_cost: 3, p_cost: 2 }
 end
 ```
 

--- a/devise-argon2.gemspec
+++ b/devise-argon2.gemspec
@@ -6,7 +6,7 @@ require "devise-argon2/version"
 Gem::Specification.new do |gem|
   gem.name = "devise-argon2"
   gem.version = Devise::Argon2::ARGON2_VERSION
-  gem.authors = ["Tamas Erdos"]
+  gem.authors = ["Tamas Erdos", "Moritz Höppner"]
   gem.email = ["tamas at tamaserdos com"]
   gem.description = %q{Enables Devise to hash passwords with Argon2id}
   gem.summary = %q{Enables Devise to hash passwords with Argon2id}
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'devise', '>= 2.1.0'
-  gem.add_dependency 'argon2', '~> 2.0'
+  gem.add_dependency 'devise', '~> 4.0'
+  gem.add_dependency 'argon2', '~> 2.1'
 
 
   gem.post_install_message = "Version 2 of devise-argon2 introduces breaking changes, please see README.md for details."


### PR DESCRIPTION
Hi @erdostom
I suggest that we also test against different versions of devise and ruby-argon2 and make the version constraints in the gemspec more strict. This is what I did in this pull request. In more detail:
- We need ruby-argon2 >= 2.1 because the HashFormat class was introduced with 2.1.0. I changed the gemspec accordingly.
- ruby-argon2 v2.1 doesn't seem to work with ruby 3.2 so I added it to the 'include' section in test.yml.
- devise 4.8 doesn't work with rails 7 so, again, I put it in the 'include' section.
- Testing older versions of devise is a hassle because they require older versions of rails. Although it would be nice to test the whole range of versions allowed by the gemspec, I suggest that we require devise ~> 4.0 and hope for the best. The current version restriction ">= 2.1.0" looks outdated and I don't think that anyone uses something below 4.0 (which was released in 2016).
- Thank you for allowing me adding myself to the authors!