### PR TITLE
Don't invoke callbacks during migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test suite
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/lib/devise-argon2/model.rb
+++ b/lib/devise-argon2/model.rb
@@ -53,8 +53,19 @@ module Devise
         attributes = { encrypted_password: password_digest(password) }
         attributes[:password_salt] = nil if migrate_hash_from_devise_argon2_v1?
 
-        self.assign_attributes(attributes)
-        self.save if self.persisted?
+        if self.persisted?
+          update_without_callbacks(attributes)
+        else
+          self.assign_attributes(attributes)
+        end
+      end
+
+      def update_without_callbacks(attributes)
+        if defined?(Mongoid) && Mongoid.models.include?(self.class)
+          self.set(attributes)
+        else
+          self.update_columns(attributes)
+        end
       end
 
       def outdated_work_factors?

--- a/spec/devise-argon2_spec.rb
+++ b/spec/devise-argon2_spec.rb
@@ -19,6 +19,7 @@ describe Devise::Models::Argon2 do
       p_cost: DEFAULT_P_COST
     }
     User.destroy_all
+    OldUser.destroy_all
   end
 
   def work_factors(hash)
@@ -126,6 +127,14 @@ describe Devise::Models::Argon2 do
 
       it 'does not update the hash if an invalid password is given' do
         expect{ user.valid_password?(INCORRECT_PASSWORD) }.not_to(change(user, :encrypted_password))
+      end
+
+      it 'does not send password change notification emails on hash updates' do
+        user.email = 'test@example.com'
+        user.save!
+        Devise.send_password_change_notification = true
+        expect{ user.valid_password?(CORRECT_PASSWORD) }
+          .not_to(change { ActionMailer::Base.deliveries.count })
       end
     end
 

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -20,5 +20,7 @@ module DummyRailsApp
     config.eager_load = false
     config.autoload_paths.reject!{ |p| p =~ /\/app\/(\w+)$/ && !%w(controllers helpers mailers views).include?($1) }
     config.autoload_paths += ["#{config.root}/app/#{ORM}"]
+    config.action_mailer.delivery_method = :test
+    config.action_mailer.default_options = { from: 'test@example.com' }
   end
 end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  devise_for :old_users
+end


### PR DESCRIPTION
This solves the issue https://github.com/erdostom/devise-argon2/issues/18.

I think it is the best option never to invoke callbacks in `update_hash`. I can't really think of a use case where one would want callbacks to be invoked there.

I still need to make all tests work, presumably there is currently some of incompatibility between two gems.