### PR TITLE
Update CI matrix & Devise version constraint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,12 @@ jobs:
         orm:
           - adapter: active_record
           - adapter: mongoid
-            mongoid-version: 9.0.2
+            mongoid-version: 9.0.3
           - adapter: mongoid
-            mongoid-version: 8.1.6
+            mongoid-version: 8.1.7
         exclude:
           - rails-version: '~> 8.0'
             ruby-version: '3.1'
-          - orm:
-              adapter: mongoid
-            rails-version: '~> 8.0'
     env:
       RAILS_VERSION: ${{ matrix.rails-version  || '~> 8.0'}}
       MONGOID_VERSION: ${{ matrix.orm.mongoid-version || '8.1.6'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['3.1', '3.2', '3.3', '3.4']
-        rails-version: ['~> 7.2', '~> 8.0']
+        rails-version: ['~> 7.2', '~> 8.0', '~> 8.1']
         argon2-version: ['2.2', '2.3']
         orm:
           - adapter: active_record
@@ -17,8 +17,13 @@ jobs:
           - adapter: mongoid
             mongoid-version: 8.1.7
         exclude:
+          - rails-version: '~> 8.1'
+            ruby-version: '3.1'
           - rails-version: '~> 8.0'
             ruby-version: '3.1'
+          - orm:
+              adapter: mongoid
+            rails-version: '~> 8.1'
     env:
       RAILS_VERSION: ${{ matrix.rails-version  || '~> 8.0'}}
       MONGOID_VERSION: ${{ matrix.orm.mongoid-version || '8.1.6'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
-        rails-version: ['~> 6.1', '~> 7.0', '~> 7.1', '~> 7.2', '~> 8.0']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        rails-version: ['~> 7.2', '~> 8.0']
         argon2-version: ['2.2', '2.3']
         orm:
           - adapter: active_record
@@ -16,62 +16,12 @@ jobs:
             mongoid-version: 9.0.2
           - adapter: mongoid
             mongoid-version: 8.1.6
-          - adapter: mongoid
-            mongoid-version: 8.0.8
-          - adapter: mongoid
-            mongoid-version: 7.5.4
         exclude:
-          - rails-version: '~> 7.2'
-            ruby-version: '2.7'
-          - rails-version: '~> 7.2'
-            ruby-version: '3.0'
-          - rails-version: '~> 8.0'
-            ruby-version: '2.7'
-          - rails-version: '~> 8.0'
-            ruby-version: '3.0'
           - rails-version: '~> 8.0'
             ruby-version: '3.1'
-          - rails-version: '~> 6.1'
-            ruby-version: '3.4'
           - orm:
               adapter: mongoid
             rails-version: '~> 8.0'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 8.0.8
-            ruby-version: '3.3'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 8.0.8
-            ruby-version: '3.4'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 8.0.8
-            ruby-version: '3.2'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 7.5.4
-            ruby-version: '3.3'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 7.5.4
-            ruby-version: '3.4'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 7.5.4
-            ruby-version: '3.2'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 8.0.8
-            rails-version: '~> 7.2'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 7.5.4
-            rails-version: '~> 7.2'
-          - orm:
-              adapter: mongoid
-              mongoid-version: 7.5.4
-            rails-version: '~> 7.1'
     env:
       RAILS_VERSION: ${{ matrix.rails-version  || '~> 8.0'}}
       MONGOID_VERSION: ${{ matrix.orm.mongoid-version || '8.1.6'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
         ruby-version: ['3.1', '3.2', '3.3', '3.4']
         rails-version: ['~> 7.2', '~> 8.0', '~> 8.1']
         argon2-version: ['2.2', '2.3']
+        devise-version: ['~> 4.9', 'main']
         orm:
           - adapter: active_record
           - adapter: mongoid

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,3 @@ if ENV['RAILS_VERSION'] == '~> 8.0'
 else
   gem 'sqlite3', '~> 1.6', '>= 1.6.6'
 end
-
-if ['~> 6.1', '~> 7.0'].include? ENV['RAILS_VERSION']
-  gem 'concurrent-ruby', '1.3.4'
-end
-

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,12 @@ gem 'simplecov'
 gem 'activerecord'
 gem 'rails', ENV['RAILS_VERSION'] || '~> 8.0'
 gem 'argon2', ENV['ARGON2_VERSION'] || '~> 2.3'
-gem 'devise', ENV['DEVISE_VERSION'] || '~> 4.9'
+
+if ENV['DEVISE_VERSION'] == 'main'
+  gem 'devise', github: 'heartcombo/devise'
+else
+  gem 'devise', ENV['DEVISE_VERSION'] || '~> 4.9'
+end
 
 if ENV['ORM'] == 'mongoid'
   gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.5'

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,4 @@ if ENV['ORM'] == 'mongoid'
   gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.5'
 end
 
-if ENV['RAILS_VERSION'] == '~> 8.0'
-  gem 'sqlite3', '~> 2.1'
-else
-  gem 'sqlite3', '~> 1.6', '>= 1.6.6'
-end
+gem 'sqlite3', '~> 2.8'

--- a/devise-argon2.gemspec
+++ b/devise-argon2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'devise', '~> 4.0'
+  gem.add_dependency 'devise', '>= 4.0'
   gem.add_dependency 'argon2', '~> 2.1'
 
 


### PR DESCRIPTION
Hi @erdostom, I updated the version matrix for the CI pipeline and allowed Devise 5 in the gemspec:

1. I removed outdated versions of dependencies from the CI pipeline. Specifically:
- Rails < 7.2 doesn't get security fixes, so I don't think we have to support it.
- Rails 7.2.0 requires at least Ruby 3.1.0, so we don't need tests for older Ruby versions.
- Mongoid 7.5 requires ActiveModel < 7.1, so we don't need to test against it.
2. By increasing the patch version of Mongoid 8.1 and 9.0, we get support for Rails 8.0 and can test against it.
3. I added Rails 8.1. As of now, Mongoid doesn't support it.
4. I added Devise main. I think this justifies relaxing the version constraint for Devise from "~> 4.0" to ">= 4.0". [*] This solves https://github.com/erdostom/devise-argon2/issues/23.

[*] Actually, I don't think that 4.0 is the most precise lower bound for the Devise version. [Devise requires Rails < 6.0 until version 4.6.2](https://github.com/heartcombo/devise/blob/v4.6.2/devise.gemspec) - so I think we could change the version constraint for Devise to ">= 4.7.0". But it probably doesn't matter since older versions can't be used anyway.